### PR TITLE
see full PR comment

### DIFF
--- a/orgamate/urls.py
+++ b/orgamate/urls.py
@@ -17,9 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from orgamateapi.views.users import UserViewSet
 from rest_framework.routers import DefaultRouter
+from orgamateapi.views import TaskViewSet
 from django.urls import path, include
 
 router = DefaultRouter(trailing_slash=False)
+router.register(r'tasks', TaskViewSet, 'task')
 
 # urlpatterns = [
 #     path('admin/', admin.site.urls),

--- a/orgamateapi/views/__init__.py
+++ b/orgamateapi/views/__init__.py
@@ -1,1 +1,2 @@
 from .users import UserViewSet
+from .tasks import TaskViewSet

--- a/orgamateapi/views/tasks.py
+++ b/orgamateapi/views/tasks.py
@@ -1,0 +1,25 @@
+from rest_framework import viewsets, status, serializers, permissions
+from rest_framework.response import Response
+
+from orgamateapi.models import Task
+
+
+class TaskSerializer(serializers.ModelSerializer):
+    #TODO: Will need to serialize priority field within here since its FK because right now will only show ID
+
+
+    def get_is_owner(self, obj):
+        # Check if the user is the owner of the review (this will still run the check and i dont need to add it to the fields! )
+        return self.context['request'].user == obj.user
+    
+    class Meta:
+        model = Task
+        fields = ['id','task_item', 'note', 'label', 'isComplete', 'date_added', 'priority']
+     
+
+class TaskViewSet(viewsets.ViewSet):
+
+    def list(self, request):
+        tasks = Task.objects.all()
+        serializer = TaskSerializer(tasks, many=True, context={'request': request}) 
+        return Response(serializer.data, status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
## I created a `tasks.py` view module to support the `task` Model. Additionally, I added the `/tasks` route to `url.py` module

## Steps to test
1. Pull down and step into the `kq-taskViewModule` branch and run cmd `code .`
2. Ensure you start the debugger
#  (will need to have an active token to check steps)
3. head to postman, and enter the url: http://localhost:8000/tasks
4. After clicking Send, you should receive empty list [] in the body AND `status code: 202 Accepted`
5. PR was created to ensure view functionality was in place before continuing further development of the view.

